### PR TITLE
ci: add support for releasing with signed tags

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,47 +2,9 @@
 
 This documents contains the necessary steps to conduct a successful release.
 
-1. Add all items to `NEWS.md`
+1. Run `tools/release.sh` shell script
 
-    Get a first template with [`clog`](https://github.com/clog-tool/clog-cli)
-    ```console
-    $ clog -F -r https://github.com/dracutdevs/dracut
-    ```
-
-2. Update the contributors list in NEWS.md
-
-   Produce the list with:
-   ```console
-   $ make CONTRIBUTORS
-   ```
-
-   Append the list to the section in `NEWS.md`
-
-3. Update AUTHORS
-
-   ```console
-   $ make AUTHORS
-   ```
-
-4. Check in AUTHORS and NEWS.md
-
-   ```console
-   $ git commit -m "docs: update NEWS.md and AUTHORS" NEWS.md AUTHORS
-   $ git push origin master
-   ```
-
-5. Tag the release, validate the tag and push
-
-   ```console
-   $ git tag -s 060
-   $ git tag -v 060
-   $ git push --tags
-   ```
-
-   Add the section from `NEWS.md` to the git tag message excluding the Rendered
-   view entry.
-
-6. Create a new release on github (https://github.com/dracutdevs/dracut/releases/new)
+2. Create a new release on github (https://github.com/dracutdevs/dracut/releases/new)
    - Add the section from `NEWS.md` to the release.
 
-7. Open a new milestone, move all unfinished issue from the previous milestone to the new one and close the released milestone (https://github.com/dracutdevs/dracut/milestones)
+3. Open a new milestone, move all unfinished issue from the previous milestone to the new one and close the released milestone (https://github.com/dracutdevs/dracut/milestones)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -18,19 +18,25 @@ else
     NEW_VERSION="$1"
 fi
 
+# change current branch to release
+git branch -m release
+
 printf "#### Contributors\n\n" > CONTRIBUTORS.md
 cat _CONTRIBUTORS >> CONTRIBUTORS.md
 
 # Update AUTHORS
 make AUTHORS
 
-# Update NEWS.md
+# Update the contributors list in NEWS.md
 cargo install clog-cli
 head -2 NEWS.md > NEWS_header.md
 tail +2 NEWS.md > NEWS_body.md
 printf "dracut-%s\n==========\n" "$NEW_VERSION" > NEWS_header_new.md
+
+# Append the list to the section in `NEWS.md`
 cat CONTRIBUTORS.md NEWS_body.md > NEWS_body_with_conttributors.md
 
+# Get a template with [`clog`](https://github.com/clog-tool/clog-cli)
 # clog will always output both the new release and old release information together
 clog -F --infile NEWS_body_with_conttributors.md -r https://github.com/dracutdevs/dracut | sed '1,2d' > NEWS_body_full.md
 
@@ -44,13 +50,33 @@ cat -s NEWS_body_new.md CONTRIBUTORS.md > release.md
 # dracut-version.sh
 printf "#!/bin/sh\n# shellcheck disable=SC2034\nDRACUT_VERSION=%s\n" "$NEW_VERSION" > dracut-version.sh
 
+if [ -z "$(git config --get user.name)" ]; then
+    git config user.name "Dracut Release Bot"
+fi
+
+if [ -z "$(git config --get user.email)" ]; then
+    git config user.email "<>"
+fi
+
 # Check in AUTHORS and NEWS.md
-git config user.name "Dracut Release Bot"
-git config user.email "<>"
 git commit -m "docs: update NEWS.md and AUTHORS" NEWS.md AUTHORS dracut-version.sh
-git push origin master
-git tag "$NEW_VERSION" -m "$NEW_VERSION"
-git push --tags
+
+# allow git push to fail in case no remote permission
+git push -u origin release || true
+
+# Tag the release, validate the tag and push
+KEYS=$(gpg --list-secret-keys --keyid-format=long 2> /dev/null)
+
+if [ -z "$KEYS" ]; then
+    echo "Could not find gpg or gpg secrets, not signing the git tag."
+    git tag "$NEW_VERSION" -m "$NEW_VERSION"
+else
+    git tag -s "$NEW_VERSION" -m "$NEW_VERSION"
+    git tag -v "$NEW_VERSION"
+fi
+
+# allow git push to fail in case no remote permission
+git push --tags || true
 
 # export new version to Github Action
 echo "new_version=${NEW_VERSION,,}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Now that tools/release.sh supports all steps described in RELEASE.md, update RELEASE.md and point it to release.sh as the canonical manual way to make a release.

